### PR TITLE
Use lower privileged user to limit risk in the case of a container breakout

### DIFF
--- a/base.dockerfile
+++ b/base.dockerfile
@@ -17,7 +17,10 @@ RUN chmod -R +x $BUILD_SCRIPTS_DIR
 RUN cd $BUILD_SCRIPTS_DIR && \
 		bash $BUILD_SCRIPTS_DIR/install-deps.sh && \
 		bash $BUILD_SCRIPTS_DIR/install-node.sh && \
+		bash $BUILD_SCRIPTS_DIR/setup-user.sh && \
 		bash $BUILD_SCRIPTS_DIR/post-install-cleanup.sh
+
+USER nodejs
 
 EXPOSE 80
 

--- a/scripts/setup-user.sh
+++ b/scripts/setup-user.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+printf "\n[-] Setting up user...\n\n"
+
+groupadd -r nodejs
+useradd -m -r -g nodejs nodejs


### PR DESCRIPTION
This is the first of some improvement PRs based on the following post:

https://nodesource.com/blog/8-protips-to-start-killing-it-when-dockerizing-node-js/

> By default, the applications process inside a Docker container runs as a “root” user. This can pose a potentially serious security risk when running in production. There have been several documented cases of container “breakouts," where an application inside a container is able to escape and make changes in the host’s environment because it has root access.

Seems to be good practice across all environments, not just production, so have included this in the base Dockerfile
