### PR TITLE
Add --unsafe-perm to meteor build

### DIFF
--- a/base.dockerfile
+++ b/base.dockerfile
@@ -1,6 +1,9 @@
 FROM debian:jessie
 MAINTAINER Jeremy Shimko <jeremy.shimko@gmail.com>
 
+RUN groupadd -r node && useradd -m -g node node
+
+ENV METEOR_VERSION 1.4.2
 ENV NODE_VERSION 4.6.1
 ENV GOSU_VERSION 1.9
 
@@ -17,8 +20,6 @@ ENV PHANTOM_VERSION 2.1.1
 ENV APP_SOURCE_DIR /opt/meteor/src
 ENV APP_BUNDLE_DIR /opt/meteor/dist
 ENV BUILD_SCRIPTS_DIR /opt/build_scripts
-
-RUN groupadd -r node && useradd -r -g node node
 
 # Add entrypoint and build scripts
 COPY scripts $BUILD_SCRIPTS_DIR

--- a/dev.dockerfile
+++ b/dev.dockerfile
@@ -1,7 +1,7 @@
 FROM jshimko/meteor-launchpad:base
 MAINTAINER Jeremy Shimko <jeremy.shimko@gmail.com>
 
-ENV DEV_BUILD "true"
+ENV DEV_BUILD true
 
 ONBUILD RUN bash $BUILD_SCRIPTS_DIR/install-meteor.sh
 ONBUILD COPY . $APP_SOURCE_DIR

--- a/scripts/build-meteor.sh
+++ b/scripts/build-meteor.sh
@@ -9,14 +9,17 @@ printf "\n[-] Building Meteor application...\n\n"
 
 cd $APP_SOURCE_DIR
 
+chown -R node $APP_SOURCE_DIR
+
 # Install app deps
-meteor npm install --unsafe-perm
+gosu node meteor npm install
 
 # build the source
 mkdir -p $APP_BUNDLE_DIR
-meteor build --unsafe-perm --directory $APP_BUNDLE_DIR
+chown -R node $APP_BUNDLE_DIR
+gosu node meteor build --directory $APP_BUNDLE_DIR
 cd $APP_BUNDLE_DIR/bundle/programs/server/
-meteor npm install --production --unsafe-perm
+gosu node meteor npm install --production
 
 # put the entrypoint script in WORKDIR
 mv $BUILD_SCRIPTS_DIR/entrypoint.sh $APP_BUNDLE_DIR/bundle/entrypoint.sh

--- a/scripts/build-meteor.sh
+++ b/scripts/build-meteor.sh
@@ -14,7 +14,7 @@ meteor npm install --unsafe-perm
 
 # build the source
 mkdir -p $APP_BUNDLE_DIR
-meteor build --directory $APP_BUNDLE_DIR
+meteor build --unsafe-perm --directory $APP_BUNDLE_DIR
 cd $APP_BUNDLE_DIR/bundle/programs/server/
 meteor npm install --production --unsafe-perm
 

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -4,9 +4,9 @@ set -e
 
 printf "\n[-] Installing base OS dependencies...\n\n"
 
-apt-get update -qq -y
+apt-get update -y
 
-apt-get install -qq -y --no-install-recommends curl ca-certificates bzip2 build-essential numactl python wget
+apt-get install -y --no-install-recommends curl ca-certificates bzip2 build-essential numactl python wget
 
 rm -rf /var/lib/apt/lists/*
 

--- a/scripts/install-meteor.sh
+++ b/scripts/install-meteor.sh
@@ -5,7 +5,7 @@ set -e
 if [ "$DEV_BUILD" = true ]; then
   # if this is a devbuild, we don't have an app to check the .meteor/release file yet,
   # so just install the latest version of Meteor
-  gosu node curl https://install.meteor.com/ | sed 's:$HOME:/home/node:g' | sh
+  curl https://install.meteor.com/ | sed 's:$HOME:/home/node:g' | sh
 else
   # download installer script
   curl https://install.meteor.com -o /home/node/install_meteor.sh
@@ -21,9 +21,8 @@ else
 
   # install
   printf "\n[-] Installing Meteor $METEOR_VERSION...\n\n"
-  chown node /home/node/install_meteor.sh
-  gosu node sh /home/node/install_meteor.sh
+  sh /home/node/install_meteor.sh
 fi
 
-# copy the executable into the $PATH
-cp /home/node/.meteor/packages/meteor-tool/$METEOR_VERSION/mt-os.linux.x86_64/scripts/admin/launch-meteor /usr/bin/meteor
+# fix permissions
+chown -R node /home/node/.meteor

--- a/scripts/install-meteor.sh
+++ b/scripts/install-meteor.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [ "$DEV_BUILD" = "true" ]; then
+if [ "$DEV_BUILD" = true ]; then
   curl https://install.meteor.com/ | sh
 else
   # download installer script

--- a/scripts/install-meteor.sh
+++ b/scripts/install-meteor.sh
@@ -3,18 +3,27 @@
 set -e
 
 if [ "$DEV_BUILD" = true ]; then
-  curl https://install.meteor.com/ | sh
+  # if this is a devbuild, we don't have an app to check the .meteor/release file yet,
+  # so just install the latest version of Meteor
+  gosu node curl https://install.meteor.com/ | sed 's:$HOME:/home/node:g' | sh
 else
   # download installer script
-  curl https://install.meteor.com -o /tmp/install_meteor.sh
+  curl https://install.meteor.com -o /home/node/install_meteor.sh
 
   # read in the release version in the app
   METEOR_VERSION=$(head $APP_SOURCE_DIR/.meteor/release | cut -d "@" -f 2)
 
   # set the release version in the install script
-  sed -i "s/RELEASE=.*/RELEASE=\"$METEOR_VERSION\"/g" /tmp/install_meteor.sh
+  sed -i.bak "s/RELEASE=.*/RELEASE=\"$METEOR_VERSION\"/g" /home/node/install_meteor.sh
+
+  # hard code the home directory for the Node user instead of using $HOME
+  sed -i.bak 's:$HOME:/home/node:g' /home/node/install_meteor.sh
 
   # install
   printf "\n[-] Installing Meteor $METEOR_VERSION...\n\n"
-  sh /tmp/install_meteor.sh
+  chown node /home/node/install_meteor.sh
+  gosu node sh /home/node/install_meteor.sh
 fi
+
+# copy the executable into the $PATH
+cp /home/node/.meteor/packages/meteor-tool/$METEOR_VERSION/mt-os.linux.x86_64/scripts/admin/launch-meteor /usr/bin/meteor


### PR DESCRIPTION
Meteor build (1.4.2) fails with this message:

> You are attempting to run Meteor as the "root" user. If you are developing,
> this is almost certainly _not_ what you want to do and will likely result in
> incorrect file permissions. However, if you are running this in a build process
> (CI, etc.) or you are absolutely sure you know what you are doing, add the
> `--unsafe-perm` flag to this command to proceed.

So the --unsafe-perm flag should probably be added to the build command too.
