### PR TITLE
Add --build-arg and remove `launchpad.conf`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,11 @@ docker run -d \
 
 ### Custom Build Options
 
-Meteor Launchpad supports a few custom build options by adding build arguments ar buildtime.
+Meteor Launchpad supports a few custom build options by adding build arguments ar buildtime. Since this effectively
+changes the build image for base, you will need to prebuild your own meteorlaunch images.
 
-```shell
-docker build -t yourname/app \
+```sh
+docker build -t yourname/meteor-launchpad:base \
 --build-arg NODE_VERSION=4.6.2 \
 --build-arg INSTALL_MONGO=false \
 --build-arg MONGO_VERSION=3.2.10 \
@@ -56,8 +57,20 @@ docker build -t yourname/app \
 --build-arg INSTALL_PHANTOMJS=false \
 --build-arg PHANTOM_VERSION=2.1.1 \
 --build-arg INSTALL_GRAPHICSMAGICK=false \
-.
+. && \
+sudo docker build --file ./prod.dockerfile --tag=yourname/meteor-launchpad:latest .
 ```
+
+Then in your Dockerfile of your app, specify your specific build.
+```Dockerfile
+FROM yourname/meteor-launchpad:latest
+```
+
+Then you can build the image with
+```sh
+sudo docker build --tag=yourname/app .
+```
+
 
 If you choose to install Mongo, you can use it by _not_ supplying a `MONGO_URL` when you run your app container.  The startup script will then start Mongo and tell your app to use it.  If you _do_ supply a `MONGO_URL`, Mongo will not be started inside the container and the external database will be used instead.
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Meteor Launchpad supports a few custom build options by adding build arguments a
 changes the build image for base, you will need to prebuild your own meteorlaunch images.
 
 ```sh
-docker build -t yourname/meteor-launchpad:base \
+docker build -t jshimko/meteor-launchpad:base \
 --build-arg NODE_VERSION=4.6.2 \
 --build-arg INSTALL_MONGO=false \
 --build-arg MONGO_VERSION=3.2.10 \
@@ -58,18 +58,23 @@ docker build -t yourname/meteor-launchpad:base \
 --build-arg PHANTOM_VERSION=2.1.1 \
 --build-arg INSTALL_GRAPHICSMAGICK=false \
 . && \
-sudo docker build --file ./prod.dockerfile --tag=yourname/meteor-launchpad:latest .
+sudo docker build --file ./prod.dockerfile --tag=jshimko/meteor-launchpad:latest .
 ```
 
 Then in your Dockerfile of your app, specify your specific build.
 ```Dockerfile
-FROM yourname/meteor-launchpad:latest
+FROM jshimko/meteor-launchpad:latest
 ```
 
 Then you can build the image with
 ```sh
 sudo docker build --tag=yourname/app .
 ```
+
+***Note:*** Since the above images can vary if you input custom build arguments, it
+will be necessary that the custom `jshimko/meteor-launchpad:base` be available locally for docker to pull from,
+otherwise it will pull the `jshimko/meteor-launchpad:base` remote image from the docker hub which will
+only have the default build variables.
 
 
 If you choose to install Mongo, you can use it by _not_ supplying a `MONGO_URL` when you run your app container.  The startup script will then start Mongo and tell your app to use it.  If you _do_ supply a `MONGO_URL`, Mongo will not be started inside the container and the external database will be used instead.

--- a/README.md
+++ b/README.md
@@ -45,14 +45,18 @@ docker run -d \
 
 ### Custom Build Options
 
-Meteor Launchpad supports a few custom build options by using a config file in the root of your app.  The currently supported options are to add PhantomJS or MongoDB to your build.  To install either of them, create a `launchpad.conf` in the root of your app and add either of the following values.
+Meteor Launchpad supports a few custom build options by adding build arguments ar buildtime.
 
-```sh
-# launchpad.conf
-
-INSTALL_PHANTOMJS=true
-INSTALL_MONGO=true
-INSTALL_GRAPHICSMAGICK=true
+```shell
+docker build -t yourname/app \
+--build-arg NODE_VERSION=4.6.2 \
+--build-arg INSTALL_MONGO=false \
+--build-arg MONGO_VERSION=3.2.10 \
+--build-arg MONGO_MAJOR=3.2 \
+--build-arg INSTALL_PHANTOMJS=false \
+--build-arg PHANTOM_VERSION=2.1.1 \
+--build-arg INSTALL_GRAPHICSMAGICK=false \
+.
 ```
 
 If you choose to install Mongo, you can use it by _not_ supplying a `MONGO_URL` when you run your app container.  The startup script will then start Mongo and tell your app to use it.  If you _do_ supply a `MONGO_URL`, Mongo will not be started inside the container and the external database will be used instead.

--- a/base.dockerfile
+++ b/base.dockerfile
@@ -3,17 +3,17 @@ MAINTAINER Jeremy Shimko <jeremy.shimko@gmail.com>
 
 RUN groupadd -r node && useradd -m -g node node
 
-ENV NODE_VERSION 4.6.2
+ARG NODE_VERSION=4.6.2
 ENV GOSU_VERSION 1.10
 
 # Optionally Install MongoDB
 ENV INSTALL_MONGO false
-ENV MONGO_VERSION 3.2.10
-ENV MONGO_MAJOR 3.2
+ARG MONGO_VERSION=3.2.10
+ARG MONGO_MAJOR=3.2
 
 # Optionally Install PhantomJS
 ENV INSTALL_PHANTOMJS false
-ENV PHANTOM_VERSION 2.1.1
+ARG PHANTOM_VERSION=2.1.1
 
 # Optionally Install Graphicsmagick
 ENV INSTALL_GRAPHICSMAGICK false

--- a/base.dockerfile
+++ b/base.dockerfile
@@ -7,16 +7,16 @@ ARG NODE_VERSION=4.6.2
 ENV GOSU_VERSION 1.10
 
 # Optionally Install MongoDB
-ENV INSTALL_MONGO false
+ARG INSTALL_MONGO=false
 ARG MONGO_VERSION=3.2.10
 ARG MONGO_MAJOR=3.2
 
 # Optionally Install PhantomJS
-ENV INSTALL_PHANTOMJS false
+ARG INSTALL_PHANTOMJS=false
 ARG PHANTOM_VERSION=2.1.1
 
 # Optionally Install Graphicsmagick
-ENV INSTALL_GRAPHICSMAGICK false
+ARG INSTALL_GRAPHICSMAGICK=false
 
 # build directories
 ENV APP_SOURCE_DIR /opt/meteor/src

--- a/base.dockerfile
+++ b/base.dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Jeremy Shimko <jeremy.shimko@gmail.com>
 RUN groupadd -r node && useradd -m -g node node
 
 ARG NODE_VERSION=4.6.2
-ENV GOSU_VERSION 1.10
+ARG GOSU_VERSION=1.10
 
 # Optionally Install MongoDB
 ARG INSTALL_MONGO=false

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -10,7 +10,7 @@ if [[ "${MONGO_URL}" == *"127.0.0.1"* ]]; then
     mongod --storageEngine=wiredTiger &
   else
     echo "ERROR: Mongo not installed inside the container."
-    echo "Rebuild with INSTALL_MONGO=true in your launchpad.conf or supply a MONGO_URL environment variable."
+    echo "Rebuild with INSTALL_MONGO=true in build time arguments."
     exit 1
   fi
 fi

--- a/scripts/install-graphicsmagick.sh
+++ b/scripts/install-graphicsmagick.sh
@@ -2,10 +2,6 @@
 
 set -e
 
-if [ -f $APP_SOURCE_DIR/launchpad.conf ]; then
-  source <(grep INSTALL_GRAPHICSMAGICK $APP_SOURCE_DIR/launchpad.conf)
-fi
-
 if [ "$INSTALL_GRAPHICSMAGICK" = true ]; then
   printf "\n[-] Installing Graphicsmagick...\n\n"
 

--- a/scripts/install-mongo.sh
+++ b/scripts/install-mongo.sh
@@ -2,10 +2,6 @@
 
 set -e
 
-if [ -f $APP_SOURCE_DIR/launchpad.conf ]; then
-  source <(grep INSTALL_MONGO $APP_SOURCE_DIR/launchpad.conf)
-fi
-
 if [ "$INSTALL_MONGO" = true ]; then
   printf "\n[-] Installing MongoDB ${MONGO_VERSION}...\n\n"
 

--- a/scripts/install-phantom.sh
+++ b/scripts/install-phantom.sh
@@ -2,11 +2,6 @@
 
 set -e
 
-if [ -f $APP_SOURCE_DIR/launchpad.conf ]; then
-  source <(grep INSTALL_PHANTOMJS $APP_SOURCE_DIR/launchpad.conf)
-  source <(grep PHANTOM_VERSION $APP_SOURCE_DIR/launchpad.conf)
-fi
-
 if [ "$INSTALL_PHANTOMJS" = true ]; then
   printf "\n[-] Installing Phantom.js...\n\n"
 


### PR DESCRIPTION
Thanks for this repository, it's great, I know nothing about meteor but this has helped a lot to learn the build process and it just works! 🌟 
I find adding a `.conf` file means learning yet another convention, use of `--build-arg` should
be easier and is already a convention for docker.
I didn't test this PR it for every different argument... 
Ref [issue 9](https://github.com/jshimko/meteor-launchpad/issues/9)
