### PR TITLE
apt-get install from launchpad.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,14 @@ Meteor Launchpad supports a few custom build options by using a config file in t
 INSTALL_PHANTOMJS=true
 INSTALL_MONGO=true
 INSTALL_GRAPHICSMAGICK=true
+INSTALL_APTGET_PACKAGES="libssl-dev"
 ```
 
 If you choose to install Mongo, you can use it by _not_ supplying a `MONGO_URL` when you run your app container.  The startup script will then start Mongo and tell your app to use it.  If you _do_ supply a `MONGO_URL`, Mongo will not be started inside the container and the external database will be used instead.
 
 Note that having Mongo in the same container as your app is just for convenience while testing/developing.  In production, you should use a separate Mongo deployment or at least a separate Mongo container.
 
+`INSTALL_APTGET_PACKAGES` allows installation additional apt-get packages prior to creating the meteor container.  Some package.json dependencies have dependencies on OS components, such as `nodegit` requires `libssl-dev` 
 
 ## Development Builds
 

--- a/README.md
+++ b/README.md
@@ -53,14 +53,14 @@ Meteor Launchpad supports a few custom build options by using a config file in t
 INSTALL_PHANTOMJS=true
 INSTALL_MONGO=true
 INSTALL_GRAPHICSMAGICK=true
-INSTALL_APTGET_PACKAGES="libssl-dev"
+INSTALL_APTGET_PACKAGES=libssl-dev
 ```
 
 If you choose to install Mongo, you can use it by _not_ supplying a `MONGO_URL` when you run your app container.  The startup script will then start Mongo and tell your app to use it.  If you _do_ supply a `MONGO_URL`, Mongo will not be started inside the container and the external database will be used instead.
 
 Note that having Mongo in the same container as your app is just for convenience while testing/developing.  In production, you should use a separate Mongo deployment or at least a separate Mongo container.
 
-`INSTALL_APTGET_PACKAGES` allows installation additional apt-get packages prior to creating the meteor container.  Some package.json dependencies have dependencies on OS components, such as `nodegit` requires `libssl-dev` 
+`INSTALL_APTGET_PACKAGES` allows installation additional apt-get packages prior to creating the meteor container.  Some package.json dependencies have dependencies on OS components, such as `nodegit` requires `libssl-dev`.  Multiple package names are ":" seperated. i.e. INSTALL_APTGET_PACKAGES=libssl-dev:locatedb:openssh-client
 
 ## Development Builds
 

--- a/base.dockerfile
+++ b/base.dockerfile
@@ -19,6 +19,9 @@ ENV PHANTOM_VERSION 2.1.1
 # Optionally Install Graphicsmagick
 ENV INSTALL_GRAPHICSMAGICK false
 
+# Optionally Install the listed apt-get packages
+ENV INSTALL_APTGET_PACKAGES ""
+
 # build directories
 ENV APP_SOURCE_DIR /opt/meteor/src
 ENV APP_BUNDLE_DIR /opt/meteor/dist

--- a/dev.dockerfile
+++ b/dev.dockerfile
@@ -6,7 +6,7 @@ ENV DEV_BUILD true
 ONBUILD RUN bash $BUILD_SCRIPTS_DIR/install-meteor.sh
 ONBUILD COPY . $APP_SOURCE_DIR
 ONBUILD RUN bash $BUILD_SCRIPTS_DIR/install-aptget-packages.sh
-ONBUILD RUN $BUILD_SCRIPTS_DIR/build-meteor.sh
+ONBUILD RUN bash $BUILD_SCRIPTS_DIR/build-meteor.sh
 
 # optionally install Mongo or Phantom at app build time
 ONBUILD RUN bash $BUILD_SCRIPTS_DIR/install-phantom.sh

--- a/dev.dockerfile
+++ b/dev.dockerfile
@@ -5,6 +5,7 @@ ENV DEV_BUILD true
 
 ONBUILD RUN bash $BUILD_SCRIPTS_DIR/install-meteor.sh
 ONBUILD COPY . $APP_SOURCE_DIR
+ONBUILD RUN bash $BUILD_SCRIPTS_DIR/install-aptget-packages.sh
 ONBUILD RUN $BUILD_SCRIPTS_DIR/build-meteor.sh
 
 # optionally install Mongo or Phantom at app build time

--- a/prod.dockerfile
+++ b/prod.dockerfile
@@ -8,6 +8,7 @@ ONBUILD COPY . $APP_SOURCE_DIR
 ONBUILD RUN bash $BUILD_SCRIPTS_DIR/install-phantom.sh
 ONBUILD RUN bash $BUILD_SCRIPTS_DIR/install-mongo.sh
 ONBUILD RUN bash $BUILD_SCRIPTS_DIR/install-graphicsmagick.sh
+ONBUILD RUN bash $BUILD_SCRIPTS_DIR/install-aptget-packages.sh
 
 # install Meteor, build app, clean up
 ONBUILD RUN cd $APP_SOURCE_DIR && \

--- a/scripts/install-aptget-packages.sh
+++ b/scripts/install-aptget-packages.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+if [ -f $APP_SOURCE_DIR/launchpad.conf ]; then
+  source <(grep INSTALL_APTGET_PACKAGES $APP_SOURCE_DIR/launchpad.conf)
+fi
+
+if [ ! -z "$INSTALL_APTGET_PACKAGES" ]; then
+  PACKAGES=${INSTALL_APTGET_PACKAGES//:/$' '}
+  printf "\n[-] Installing additional apt-get packages: ${PACKAGES}...\n\n"
+
+  apt-get update -y
+  apt-get install -y ${PACKAGES}
+fi


### PR DESCRIPTION
This update extends the existing launchpad.conf file to allow the user to install additional apt-get packages that their npm dependencies require

For example: if a user of `nodegit` requires `libssl` to be installed before the application is built, they can update their local `launchpad.conf` with
`INSTALL_APTGET_PACKAGES=libssl-dev`
