### PR TITLE
Use keyservers on port 80

### DIFF
--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -33,7 +33,7 @@ wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/downloa
 
 export GNUPGHOME="$(mktemp -d)"
 
-gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
+gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
 gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu
 
 rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc

--- a/scripts/install-mongo.sh
+++ b/scripts/install-mongo.sh
@@ -9,7 +9,7 @@ fi
 if [ "$INSTALL_MONGO" = true ]; then
   printf "\n[-] Installing MongoDB ${MONGO_VERSION}...\n\n"
 
-	apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 0C49F3730359A14518585931BC711F9BA15703C6
+	apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 0C49F3730359A14518585931BC711F9BA15703C6
 
   echo "deb http://repo.mongodb.org/apt/debian jessie/mongodb-org/$MONGO_MAJOR main" > /etc/apt/sources.list.d/mongodb-org.list
 


### PR DESCRIPTION
Support corporate firewalls that block the default port.

Fix for https://github.com/jshimko/meteor-launchpad/issues/58