### PR TITLE
Update post-build-cleanup.sh

### DIFF
--- a/scripts/post-build-cleanup.sh
+++ b/scripts/post-build-cleanup.sh
@@ -24,7 +24,7 @@ rm -rf /root/{.npm,.cache,.config,.cordova,.local}
 rm -rf /tmp/*
 
 # remove npm
-npm cache clean
+npm cache clean --force
 rm -rf /opt/nodejs/bin/npm
 rm -rf /opt/nodejs/lib/node_modules/npm/
 


### PR DESCRIPTION
Hi @jshimko !

Receiving this error on `npm cache clean`

```
npm ERR! As of npm@5, the npm cache self-heals from corruption issues and data extracted from the cache is guaranteed to be valid. If you want to make sure everything is consistent, use 'npm cache verify' instead.
npm ERR!
npm ERR! If you're sure you want to delete the entire cache, rerun this command with --force.

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2017-11-03T03_48_28_600Z-debug.log
The command '/bin/sh -c cd $APP_SOURCE_DIR &&   $BUILD_SCRIPTS_DIR/install-deps.sh &&   $BUILD_SCRIPTS_DIR/install-node.sh &&   $BUILD_SCRIPTS_DIR/install-phantom.sh &&   $BUILD_SCRIPTS_DIR/install-graphicsmagick.sh &&   $BUILD_SCRIPTS_DIR/install-mongo.sh &&   $BUILD_SCRIPTS_DIR/install-meteor.sh &&   $BUILD_SCRIPTS_DIR/build-meteor.sh &&   $BUILD_SCRIPTS_DIR/post-build-cleanup.sh' returned a non-zero code: 1
```

Added the option `--force`. 