### PR TITLE
Add wait-for-it functionality to facilitate network-based waits

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,9 @@ ENV APP_SOURCE_DIR /opt/meteor/src
 ENV APP_BUNDLE_DIR /opt/meteor/dist
 ENV BUILD_SCRIPTS_DIR /opt/build_scripts
 
+# wait-for-it
+ENV WAIT_FOR_SECONDS=15
+
 # Add entrypoint and build scripts
 COPY scripts $BUILD_SCRIPTS_DIR
 RUN chmod -R 750 $BUILD_SCRIPTS_DIR

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ docker run -d \
   yourname/app
 ```
 
-#### Delay startup
+#### Delay Startup Based on Time
 
 If you need to force a delay in the startup of the Node process (for example, to wait for a database to be ready), you can set the `STARTUP_DELAY` environment variable to any number of seconds.  For example, to delay starting the app by 10 seconds, you would do this:
 
@@ -49,6 +49,24 @@ docker run -d \
   -e ROOT_URL=http://example.com \
   -e MONGO_URL=mongodb://url \
   -e STARTUP_DELAY=10 \
+  -p 80:3000 \
+  yourname/app
+```
+
+#### Delay Startup Based on Network Connection
+If you need to force a delay in startup of the node process while waiting for
+the database (or some other TCP service) to be ready after
+```WAIT_FOR_SECONDS``` seconds (the default if unspecified is 15 seconds), use
+```WAIT_FOR```. To make the container refuse to start without being able to
+contact the service, set the variable ```WAIT_FOR_REQUIRED``` to a value.
+
+```sh
+docker run -d \
+  -e ROOT_URL=http://example.com \
+  -e MONGO_URL=mongodb://url \
+  -e WAIT_FOR_SECONDS=13 \
+  -e WAIT_FOR_REQUIRED=1 \
+  -e WAIT_FOR=host:port \
   -p 80:3000 \
   yourname/app
 ```

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -20,6 +20,16 @@ if [[ $STARTUP_DELAY ]]; then
   sleep $STARTUP_DELAY
 fi
 
+# Wait for network service
+if [[ ! -z $WAIT_FOR ]]; then
+  wait_for_args=" --timeout=$WAIT_FOR_SECONDS $WAIT_FOR -- echo \"done waiting for $WAIT_FOR\""
+  if [[ ! -z $WAIT_FOR_REQUIRED ]]; then
+    wait-for-it.sh --strict $wait_for_args
+  else
+    wait-for-it.sh $wait_for_args
+  fi
+fi
+
 if [ "${1:0:1}" = '-' ]; then
 	set -- node "$@"
 fi

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -30,6 +30,7 @@ dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"
 
 wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"
 wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"
+wget -O /usr/local/bin/wait-for-it.sh https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh
 
 export GNUPGHOME="$(mktemp -d)"
 
@@ -38,8 +39,9 @@ gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu
 
 rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc
 
-chmod +x /usr/local/bin/gosu
+chmod +x /usr/local/bin/gosu /usr/local/bin/wait-for-it.sh
 
 gosu nobody true
 
 apt-get purge -y --auto-remove wget
+


### PR DESCRIPTION
* Add instructions in README
* Add default wait of 15 seconds in Dockerfile
* Add fetching of application in install-deps.sh
* Add checking of environment variables to conditionally use wait-for-it.sh
* Closes #101 