### PR TITLE
Install latest meteor and upgrade afterwards

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:stretch
 MAINTAINER Jeremy Shimko <jeremy.shimko@gmail.com>
 
 RUN groupadd -r node && useradd -m -g node node

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -21,25 +21,4 @@ if [ -f $APP_SOURCE_DIR/launchpad.conf ]; then
   fi
 fi
 
-apt-get install -y --no-install-recommends curl bzip2 bsdtar build-essential python git wget
-
-
-# install gosu
-
-dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"
-
-wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"
-wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"
-
-export GNUPGHOME="$(mktemp -d)"
-
-gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
-gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu
-
-rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc
-
-chmod +x /usr/local/bin/gosu
-
-gosu nobody true
-
-apt-get purge -y --auto-remove wget
+apt-get install -y --no-install-recommends curl bzip2 bsdtar build-essential python git gnupg gosu

--- a/scripts/install-meteor.sh
+++ b/scripts/install-meteor.sh
@@ -15,13 +15,18 @@ else
   METEOR_VERSION=$(head $APP_SOURCE_DIR/.meteor/release | cut -d "@" -f 2)
 
   # set the release version in the install script
-  sed -i.bak "s/RELEASE=.*/RELEASE=\"$METEOR_VERSION\"/g" /tmp/install_meteor.sh
+  # sed -i.bak "s/RELEASE=.*/RELEASE=\"$METEOR_VERSION\"/g" /tmp/install_meteor.sh
 
   # replace tar command with bsdtar in the install script (bsdtar -xf "$TARBALL_FILE" -C "$INSTALL_TMPDIR")
   # https://github.com/jshimko/meteor-launchpad/issues/39
   sed -i.bak "s/tar -xzf.*/bsdtar -xf \"\$TARBALL_FILE\" -C \"\$INSTALL_TMPDIR\"/g" /tmp/install_meteor.sh
 
   # install
-  printf "\n[-] Installing Meteor $METEOR_VERSION...\n\n"
+  printf "\n[-] Installing latest Meteor...\n\n"
   sh /tmp/install_meteor.sh
+
+  # update meteor to desired version
+  printf "\n[-] Updating Meteor to $METEOR_VERSION...\n\n"
+  export METEOR_ALLOW_SUPERUSER=true
+  meteor update --release $METEOR_VERSION
 fi


### PR DESCRIPTION
Only the latest stable versions are available via the current installation script, because meteor does not host all versions bootstrapped on their CDN.
As a workaround we will install the latest meteor and upgrade afterwards.

Should fix #111