### PR TITLE
Making npm install verbose

### DIFF
--- a/scripts/build-meteor.sh
+++ b/scripts/build-meteor.sh
@@ -23,7 +23,7 @@ cd $APP_SOURCE_DIR
 
 # Install app deps
 printf "\n[-] Running npm install in app directory...\n\n"
-meteor npm install
+meteor npm install --verbose
 
 # build the bundle
 printf "\n[-] Building Meteor application...\n\n"


### PR DESCRIPTION
I had some trouble with some npm packages not installing, this makes that easier to spot. I don't really see a reason not to set it to verbose.